### PR TITLE
feat: add ClaudeCode Launchpad CLI note to setup section

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ It's essentially like having a very pair programming partner who can jump in and
 [![Anthropic](Images/Anthropic.png)](https://www.anthropic.com)
 
 [![Claude Installation](Images/claude-installation.png)](https://docs.anthropic.com/en/docs/claude-code/overview)
+> **Windows or macOS?** [ClaudeCode Launchpad CLI](https://github.com/noambrand/kivun-terminal) is a community installer that sets up Node.js, Git, and Claude Code in about 2 minutes — no manual steps. Includes a two-line status bar, folder picker, and optional terminal theme. [Download latest release](https://github.com/noambrand/kivun-terminal/releases/latest).
 
 ---
 ### Prompt Engineering Deep Dive


### PR DESCRIPTION
## What

Adds a brief callout under **Claude Code Setup** pointing Windows and macOS users to [ClaudeCode Launchpad CLI](https://github.com/noambrand/kivun-terminal) as a community installer option.

## Why

The current setup section links to the official Anthropic installation docs, which requires manually installing Node.js, then Claude Code via npm. For Windows users especially, this can take 30+ minutes and involves multiple manual steps.

ClaudeCode Launchpad CLI handles the full setup automatically in ~2 minutes and adds:

- Two-line live status bar (model, context %, token count, session/weekly limits)
- Folder picker GUI and right-click context menu (Windows)
- Optional light-blue terminal theme
- Claude flags support (e.g. `--continue`) from the launcher

The note is a single callout line — minimal footprint, high value for readers who are on Windows or macOS and want a faster path to their first `claude` session.

MIT licensed, open source.  
**GitHub:** https://github.com/noambrand/kivun-terminal  
**Latest release:** https://github.com/noambrand/kivun-terminal/releases/latest