### PR TITLE
Add Vexilo · A field guide to Claude Code to References

### DIFF
--- a/README.md
+++ b/README.md
@@ -854,6 +854,7 @@ A curated set of pointers — official Anthropic docs, MCP resources, hooks exam
 - [Building effective agents (Anthropic engineering)](https://www.anthropic.com/engineering/building-effective-agents)
 - [Official MCP Registry](https://registry.modelcontextprotocol.io/)
 - [Hooks reference (official)](https://docs.anthropic.com/en/docs/claude-code/hooks)
+- [Vexilo · A field guide to Claude Code](https://vexilo.app/?lang=en) — Interactive visual index of 31 agents · 99 commands · 123 skills · 13 rules, organized around the 5-step workflow. One-click "Teach Claude this handbook" primes your local Claude session with the whole index in 30 seconds. ([companion repo](https://github.com/lilhawk7077/claude-code-resources))
 
 ---
 


### PR DESCRIPTION
## Adds Vexilo · A field guide to Claude Code to the References section

[Vexilo](https://vexilo.app/?lang=en) is a live, interactive, visual index of **31 agents · 99 commands · 123 skills · 13 rules**, organized around the 5-step workflow (Research → Plan → Test-first → Security → Commit). One-click **"Teach Claude this handbook"** feeds the whole index into a local Claude session in 30 seconds.

### Why it fits "References"
This repo's References section is "curated pointers to official Anthropic docs, MCP resources, hooks examples, workflow tutorials, pricing references, and adjacent tooling." Vexilo fits as **adjacent tooling** — a navigation layer over the same ecosystem this guide covers.

### Entry details
- URL: https://vexilo.app/?lang=en
- Companion repo (MIT): https://github.com/lilhawk7077/claude-code-resources
- v1.1.9, weekly updates

### Checklist
- [x] Adjacent tooling (not a duplicate of anything listed)
- [x] Actively maintained
- [x] Open and free
- [x] Companion repo MIT-licensed