### PR TITLE
fix: add missing YAML frontmatter to six command files

### DIFF
--- a/.claude/commands/five.md
+++ b/.claude/commands/five.md
@@ -1,3 +1,8 @@
+---
+name: five
+description: Apply the Five Whys root cause analysis technique to investigate an issue
+---
+
 # Five Whys Analysis
 
 Apply the Five Whys root cause analysis technique to investigate issues.

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -1,3 +1,8 @@
+---
+name: pr
+description: Create a branch, split changes into logical commits, and open a pull request
+---
+
 # Create Pull Request Command
 
 Create a new branch, commit changes, and submit a pull request.

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -1,3 +1,8 @@
+---
+name: review
+description: Run a multi-perspective PR review (product, dev, QA, security, DevOps, UX) and post it to GitHub
+---
+
 # PR Review
 
 **PR Link/Number**: $ARGUMENTS

--- a/.claude/commands/tdd.md
+++ b/.claude/commands/tdd.md
@@ -1,3 +1,8 @@
+---
+name: tdd
+description: Development practices and TDD workflow to follow before starting a feature
+---
+
 This outlines the development practices and principles we require you to follow. Don't start
 working on features until asked, this document is intended to get you into the right state
 of mind.

--- a/.claude/commands/test.md
+++ b/.claude/commands/test.md
@@ -1,3 +1,8 @@
+---
+name: test
+description: LLM unit testing best practices checklist for testing internal logic, not API endpoints
+---
+
 # ✅ LLM Unit Testing Best Practices Checklist  
 _Focused on testing internal logic, not API endpoints_
 

--- a/.claude/commands/ux.md
+++ b/.claude/commands/ux.md
@@ -1,3 +1,8 @@
+---
+name: ux
+description: User Experience Designer & UI Specialist persona for design-focused tasks
+---
+
 # User Experience Designer & UI Specialist Persona
 
 Represents an empathetic, creative, detail-oriented design professional focused on crafting intuitive, user-obsessed, and data-informed experiences.


### PR DESCRIPTION
> **Automated**: drive-by fix from [NLPM](https://github.com/xiaolai/nlpm), an NL artifact linter. Reviewed and reproduced before submission.

**Bug**: `five.md`, `pr.md`, `review.md`, `tdd.md`, `test.md`, and `ux.md` in `.claude/commands/` have no YAML frontmatter, unlike `todo.md` which uses a `name`/`description` block.

**Evidence**: `head -3` on each file shows the body starting directly with a `#` heading or prose — no leading `---` block; confirmed by diffing against `todo.md`'s frontmatter format.

**Fix**: Add a `---\nname: <cmd>\ndescription: <one line>\n---` frontmatter block to each file, matching `todo.md`'s existing style.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"BUG-missing-frontmatter","fingerprint":"sha256:94cb177e319ed4c2092f2d511a7dbc5225fa32f4831b0f9a6b251c751546adfe"},{"rule_id":"BUG-missing-frontmatter","fingerprint":"sha256:e27726e5819a1178bf9680ce99bab1d02c5f7933069f8dce478e082c67092f59"},{"rule_id":"BUG-missing-frontmatter","fingerprint":"sha256:453e07058fac85c055141b81010eec3347e99037f128774a2fc3240d2bb9774c"},{"rule_id":"BUG-missing-frontmatter","fingerprint":"sha256:04c4e4e8d57455ea70e5ce2e855581b5811887ea6f4c50f2bdb100c7e51a4cd7"},{"rule_id":"BUG-missing-frontmatter","fingerprint":"sha256:885b4ae311cb5371022a80c6e7d3b3565d11c3f4298c45e81f26f5774265599d"},{"rule_id":"BUG-missing-frontmatter","fingerprint":"sha256:0db8bd7e8f6ecb10564ee9e3e1991eead9d389d776a0218eb314fe5ada76d7f8"}]}
nlpm-metadata-end -->