### PR TITLE
fix: use bare uv command in notification.py instead of hardcoded path

### DIFF
--- a/.claude/hooks/notification.py
+++ b/.claude/hooks/notification.py
@@ -68,7 +68,7 @@ def announce_notification():
         
         # Call the TTS script with the notification message
         subprocess.run([
-            "/Users/wesam/.local/bin/uv", "run", tts_script, notification_message
+            "uv", "run", tts_script, notification_message
         ], 
         capture_output=True,  # Suppress output
         timeout=10  # 10-second timeout


### PR DESCRIPTION
> **Automated**: drive-by fix from [NLPM](https://github.com/xiaolai/nlpm), an NL artifact linter. Reviewed and reproduced before submission.

**Bug**: `notification.py` hardcodes `/Users/wesam/.local/bin/uv` in its `subprocess.run()` call instead of the bare `uv` command used everywhere else.

**Evidence**: Reproduced locally — `subprocess.run(["/Users/wesam/.local/bin/uv", "--version"], ...)` raises `FileNotFoundError: [Errno 2] No such file or directory: '/Users/wesam/.local/bin/uv'` on any machine without that exact path (the TTS notification then silently fails since `FileNotFoundError` is caught). `stop.py` and `subagent_stop.py` both already call plain `"uv"`, which resolves correctly via `PATH`.

**Fix**: Replace the hardcoded path with `"uv"`, matching `stop.py`/`subagent_stop.py`.

<!-- nlpm-metadata-begin
{"version":1,"findings":[]}
nlpm-metadata-end -->